### PR TITLE
Add Python 3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 dist: xenial  # required for Python >= 3.7
+sudo: false
 language: python
+python:
+  - "3.6"
+  - "3.7"
+  - "3.8"
+  - "pypy3"
 cache: pip
-matrix:
-  include:
-    - name: "3.6"
-      python: 3.6
-    - name: "3.7"
-      python: 3.7
-before_install:
-- pip install poetry
-install:
-- poetry install -v
-script:
-- pytest
+install: pip install tox-travis
+script: tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,5 +31,5 @@ pytest = "^5.0"
 flake8-markdown = 'flake8_markdown:main'
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry>=1.0.0b9"]
 build-backend = "poetry.masonry.api"

--- a/tests/test_flake8_markdown.py
+++ b/tests/test_flake8_markdown.py
@@ -84,7 +84,10 @@ def test_run_with_file_containing_pycon_blocks(run_flake8_markdown):
     error_count = len(output.splitlines())
     assert error_count == 3
     assert 'tests/samples/pycon.md:10:11: F821' in output
-    assert 'tests/samples/pycon.md:17:10: E999' in output
+    if 'PyPy' in sys.version:
+        assert 'tests/samples/pycon.md:17:1: E999' in output
+    else:
+        assert 'tests/samples/pycon.md:17:10: E999' in output
     assert 'tests/samples/pycon.md:25:1: F821' in output
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,17 @@
 [tox]
 skipsdist = True
-envlist = py36, py37, pypy3
+envlist = py36, py37, py38, pypy3
 
 [testenv]
-whitelist_externals = poetry
+whitelist_externals =
+    poetry
+    pytest
+    flake8-markdown
 skip_install = true
+commands_pre =
+    pip install "poetry>=1.0.0b9" "pip>=19.3.1"
+    poetry export -f requirements.txt -o requirements.txt
 commands =
-    poetry install -v
-    poetry run pytest
+    pip install -r requirements.txt
+    pip install .
+    pytest


### PR DESCRIPTION
Adds Python 3.8 support and fixes a failing test with PyPy3.

Also updates Poetry to v1.0.0b9 and uses `poetry export` to create a `requirements.txt` file to install with `pip` instead of using `poetry install`, which created an extra virtual environment.