### PR TITLE
add support for shorthand py codeblocks

### DIFF
--- a/flake8_markdown/__init__.py
+++ b/flake8_markdown/__init__.py
@@ -45,7 +45,7 @@ regex_rule = ''.join([
     # Use non-matching group instead of a lookbehind because the code
     # block may have line highlighting hints. See:
     # https://python-markdown.github.io/extensions/fenced_code_blocks/#emphasized-lines
-    non_matching_group('^```(python|pycon).*$'),
+    non_matching_group('^```(python|pycon|py).*$'),
     matching_group(ONE_OR_MORE_LINES_NOT_GREEDY),
     non_matching_lookahead('^```')
 ])

--- a/tests/samples/basic.md
+++ b/tests/samples/basic.md
@@ -13,3 +13,12 @@ This code block references an undefined variable:
 ```python
 print(undefined_variable)
 ```
+
+This code block uses the shorthand py and has an unused import
+
+```py
+import os
+
+
+print('hello hello world')
+```

--- a/tests/test_flake8_markdown.py
+++ b/tests/test_flake8_markdown.py
@@ -54,6 +54,8 @@ def test_run_with_matching_single_file_with_linting_errors(run_flake8_markdown):
     else:
         assert 'tests/samples/basic.md:8:48: E999' in output
     assert 'tests/samples/basic.md:14:7' in output
+    # this case covers the shorthand ```py
+    assert 'tests/samples/basic.md:20:1: F401' in output
 
 
 def test_run_with_matching_single_file_wihout_linting_errors(run_flake8_markdown):


### PR DESCRIPTION
markdown also allows using ```py for starting code blocks, those are currently ignored. I tried adding support for this.