### PR TITLE
Remove upper bound on flake8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
-flake8 = ">=3.0,<5.0"
+flake8 = ">=3.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.0"


### PR DESCRIPTION
Normally, I would just change this to <6.0. However given that this is
not a very active project, I think it best to remove the upper bound on
flake8.

Let me know if you would prefer to keep the bound to <6.0 instead.

Closes #13 